### PR TITLE
Switch to fil_pasta_curves fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cuda-mobile = []
 [dependencies]
 semolina = "~0.1.2"
 sppark = "~0.1.2"
-pasta_curves = { version = "0.5.1", features = ["repr-c"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.5.2", features = ["repr-c"], package = "fil_pasta_curves" }
 
 [build-dependencies]
 cc = "^1.0.70"
@@ -45,6 +45,3 @@ rayon = "1.5"
 [[bench]]
 name = "main"
 harness = false
-
-[patch.crates-io]
-fil_pasta_curves = { git = "https://github.com/lurk-lang/pasta_curves", branch = "serde" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cuda-mobile = []
 [dependencies]
 semolina = "~0.1.2"
 sppark = "~0.1.2"
-pasta_curves = { version = "0.4.0", features = ["repr-c"] }
+pasta_curves = { version = "0.5.1", features = ["repr-c"], package = "fil_pasta_curves" }
 
 [build-dependencies]
 cc = "^1.0.70"
@@ -47,4 +47,4 @@ name = "main"
 harness = false
 
 [patch.crates-io]
-pasta_curves = { git = "https://github.com/lurk-lang/pasta_curves", branch = "serde-ep-eq" }
+fil_pasta_curves = { git = "https://github.com/lurk-lang/pasta_curves", branch = "serde" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cuda-mobile = []
 [dependencies]
 semolina = "~0.1.2"
 sppark = "~0.1.2"
-pasta_curves = { version = ">=0.3.1, <=0.4", features = ["repr-c"] }
+pasta_curves = { version = "0.5.1", features = ["repr-c"], package = "fil_pasta_curves" }
 
 [build-dependencies]
 cc = "^1.0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cuda-mobile = []
 [dependencies]
 semolina = "~0.1.2"
 sppark = "~0.1.2"
-pasta_curves = { version = "0.5.1", features = ["repr-c"], package = "fil_pasta_curves" }
+pasta_curves = { version = "0.4.0", features = ["repr-c"] }
 
 [build-dependencies]
 cc = "^1.0.70"
@@ -45,3 +45,6 @@ rayon = "1.5"
 [[bench]]
 name = "main"
 harness = false
+
+[patch.crates-io]
+pasta_curves = { git = "https://github.com/lurk-lang/pasta_curves", branch = "serde-ep-eq" }


### PR DESCRIPTION
This will allow Nova and Lurk to serialize proofs without bumping to `pasta_curves` v0.5 yet